### PR TITLE
pangram: Add test case with repeated letters in both upper and lower cases

### DIFF
--- a/exercises/pangram/src/test/kotlin/PangramTest.kt
+++ b/exercises/pangram/src/test/kotlin/PangramTest.kt
@@ -43,6 +43,11 @@ class PangramTest {
     fun mixedCaseAndPunctuation() {
         assertTrue(Pangrams.isPangram("\"Five quacking Zephyrs jolt my wax bed.\""))
     }
+    
+    @Test
+    fun mixedCaseDuplicatedCharacters() {
+        assertFalse(Pangrams.isPangram("the quick brown fox jumps over the lazy FOX"))
+    }
 
     @Test
     fun nonAsciiCharacters() {


### PR DESCRIPTION
My initial solution to the pangram problem was as follows:

``` kotlin
fun isPangram(sentence: String): Boolean {
    return sentence
            .filter { it.isLetter() }
            .toList()
            .distinct()
            .count() >= 26
}
```

This passes all the existing tests, but fails the newly-added test because I did not explicitly ignore case before calling `.distinct`.
