### PR TITLE
etl: adjust tests to match description

### DIFF
--- a/exercises/etl/src/example/kotlin/ETL.kt
+++ b/exercises/etl/src/example/kotlin/ETL.kt
@@ -1,5 +1,5 @@
 object ETL {
-    fun transform(old: Map<Int, Collection<String>>): Map<String, Int> {
+    fun transform(old: Map<Int, Collection<Char>>): Map<Char, Int> {
         return old.flatMap { mapEntry -> mapEntry.value.map { word -> Pair(word.toLowerCase(), mapEntry.key) } }.toMap()
     }
 }

--- a/exercises/etl/src/test/kotlin/ETLTest.kt
+++ b/exercises/etl/src/test/kotlin/ETLTest.kt
@@ -5,24 +5,24 @@ class ETLTest {
 
     @Test
     fun transformOneValue() {
-        val old = mapOf(1 to listOf("WORLD"))
-        val expected = mapOf("world" to 1)
+        val old = mapOf(1 to listOf('a'))
+        val expected = mapOf('a' to 1)
 
         assertEquals(expected, ETL.transform(old))
     }
 
     @Test
     fun transformMoreValues() {
-        val old = mapOf(1 to listOf("WORLD", "GSCHOOLERS"))
-        val expected = mapOf("world" to 1, "gschoolers" to 1)
+        val old = mapOf(1 to listOf('A', 'E', 'I'))
+        val expected = mapOf('a' to 1, 'e' to 1, 'i' to 1)
 
         assertEquals(expected, ETL.transform(old))
     }
 
     @Test
     fun moreKeys() {
-        val old = mapOf(1 to listOf("APPLE", "ARTICHOKE"), 2 to listOf("BOAT", "BALLERINA"))
-        val expected = mapOf("apple" to 1, "artichoke" to 1, "boat" to 2, "ballerina" to 2)
+        val old = mapOf(1 to listOf('A', 'E', 'I'), 2 to listOf('D', 'G'))
+        val expected = mapOf('a' to 1, 'e' to 1, 'i' to 1, 'd' to 2, 'g' to 2)
 
         assertEquals(expected, ETL.transform(old))
     }
@@ -30,21 +30,21 @@ class ETLTest {
     @Test
     fun fullDataset() {
         val old = mapOf(
-                1 to listOf("A", "E", "I", "O", "U", "L", "N", "R", "S", "T"),
-                2 to listOf("D", "G"),
-                3 to listOf("B", "C", "M", "P"),
-                4 to listOf("F", "H", "V", "W", "Y"),
-                5 to listOf("K"),
-                8 to listOf("J", "X"),
-                10 to listOf("Q", "Z")
+                1 to listOf('A', 'E', 'I', 'O', 'U', 'L', 'N', 'R', 'S', 'T'),
+                2 to listOf('D', 'G'),
+                3 to listOf('B', 'C', 'M', 'P'),
+                4 to listOf('F', 'H', 'V', 'W', 'Y'),
+                5 to listOf('K'),
+                8 to listOf('J', 'X'),
+                10 to listOf('Q', 'Z')
         )
         val expected = mapOf(
-                "a" to 1, "b" to 3, "c" to 3, "d" to 2, "e" to 1,
-                "f" to 4, "g" to 2, "h" to 4, "i" to 1, "j" to 8,
-                "k" to 5, "l" to 1, "m" to 3, "n" to 1, "o" to 1,
-                "p" to 3, "q" to 10, "r" to 1, "s" to 1, "t" to 1,
-                "u" to 1, "v" to 4, "w" to 4, "x" to 8, "y" to 4,
-                "z" to 10
+                'a' to 1, 'b' to 3, 'c' to 3, 'd' to 2, 'e' to 1,
+                'f' to 4, 'g' to 2, 'h' to 4, 'i' to 1, 'j' to 8,
+                'k' to 5, 'l' to 1, 'm' to 3, 'n' to 1, 'o' to 1,
+                'p' to 3, 'q' to 10, 'r' to 1, 's' to 1, 't' to 1,
+                'u' to 1, 'v' to 4, 'w' to 4, 'x' to 8, 'y' to 4,
+                'z' to 10
         )
 
         assertEquals(expected, ETL.transform(old))


### PR DESCRIPTION
The description for this exercise establishes a background where the program is transforming scrabble score configuration.  However, all but the last test in the suite use whole words as keys.  While *technically* correct, this difference between the description and the test suite represents accidental complexity rather than a challenge inherent in the exercise, itself.

The word-based implementation is a remnant of an implementation choice that was propagated but since rejected: exercism/xcpp#68.

This is the same work as on other tracks:

- exercism/xerlang#64
- exercism/xobjective-c#6