### PR TITLE
Update installation and getting started instructions.

### DIFF
--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -1,154 +1,250 @@
-## Windows
+# Installing Kotlin
 
-If you are new-ish to programming in Java, these instructions are for you. This is a step-by-step opinionated guide to getting from zero to submitting your first exercise.
+In addition to the exercism CLI and your favorite text editor, practicing with Exercism exercises in Kotlin requires
+
+* the **Java Development Kit** (JDK) — Kotlin compiles to Java bytecodes; you need to install the JDK which includes both a Java Runtime *and* development tools (most notably, the Java compiler); and
+* **Gradle** — a build tool specifically for JVM-based projects and supports Kotlin.
+
+Choose your operating system:
+
+* [Windows](#windows)
+* [Mac OS X](#mac-os-x)
+* [Linux](#linux)
+
+... or ...
+* if you prefer to not use a package maanger, you can [install manually](#install-manually).
+
+Optionally, you can also use a [Java IDE](#java-ides).
+
+----
+
+# Windows
+
+Open an administrative command prompt.  (If you need assistance opening an administrative prompt, see [open an elevated prompt in Windows 8+](http://www.howtogeek.com/194041/how-to-open-the-command-prompt-as-administrator-in-windows-8.1/) (or [Windows 7](http://www.howtogeek.com/howto/windows-vista/run-a-command-as-administrator-from-the-windows-vista-run-box/)).
+
+1. If you have not installed Chocolatey, do so now:
+
+   ```batchfile
+   C:\Windows\system32> @powershell -NoProfile -ExecutionPolicy unrestricted -Command "iex ((new-object net.webclient).DownloadString('https://chocolatey.org/install.ps1'))" && SET PATH=%PATH%;%ALLUSERSPROFILE%\chocolatey\bin
+   ```
+2.  Install the JDK:
+
+   ```batchfile
+   C:\Windows\system32> choco install jdk8
+   ...
+   C:\Windows\system32> refreshenv
+   ...
+   ```
+3.  Install Gradle:
+
+   ```batchfile
+   C:\Windows\system32>choco install gradle
+   ...
+   ```
+
+We recommend closing the administrative command prompt and opening a new command prompt -- you do not require administrator priviledges to practice Exercism exercises.
+
+You now are ready to get started with the Kotlin track of Exercism!
+
+To get started, see "[Running the Tests](http://exercism.io/languages/kotlin/tests)".
+
+----
+
+# Mac OS X
+
+Below are instructions for install using the most common method - using Homebrew.  If you'd rather, you can also [install on OS X without Homebrew](#installing-on-mac-os-x-without-homebrew).
+
+## Installing
+
+1. If you haven't installed [Homebrew](http://brew.sh), yet, do so now:
+
+   ```sh
+   $ /usr/bin/ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"
+   ```
+2. Tap the [Homebrew Cask](https://caskroom.github.io/) — this allows us to install pre-built binaries like the JDK.
+
+   ```
+   $ brew tap caskroom/cask
+   ```
+3.  Install the JDK:
+
+   ```
+   $ brew cask install java
+   ```
+4.  Install Gradle:
+
+   ```
+   $ brew install gradle
+   ```
+
+You now are ready to get started with the Kotlin track of Exercism!
+
+To get started, see "[Running the Tests](http://exercism.io/languages/kotlin/tests)".
+
+----
+
+# Linux
+
+Below are instructions for install using the package manager of your distro.  If you'd rather, you can also [install on Linux without a package manager](#installing-on-linux-without-a-package-manager).
+
+* [Debian](#debian)
+* [Fedora](#fedora)
+
+## Debian
+
+If you are using Debian or its derivatives (like Ubuntu or Linux Mint), use APT:
+
+*(verified on: Linux Mint 18, Ubuntu 14)*
+
+1. Install the JDK:
+
+   ```sh
+   $ sudo apt-get update
+   $ sudo apt-get install python-software-properties
+   $ sudo add-apt-repository ppa:webupd8team/java
+   $ sudo apt-get update
+   $ sudo apt-get install oracle-java8-installer
+   $ sudo apt install oracle-java8-set-default
+   ```
+2. Install Gradle:
+
+   ```sh
+   $ sudo add-apt-repository ppa:cwchien/gradle
+   $ sudo apt-get update
+   $ sudo apt-get install gradle
+   ```
+
+You now are ready to get started with the Kotlin track of Exercism!
+
+To get started, see "[Running the Tests](http://exercism.io/languages/kotlin/tests)".
+
+----
+
+## Fedora
+
+If you are using Fedora or its derivatives, use DNF:
+
+*(verified on: Fedora 24)*
+
+1. Install the JDK:
+
+   ```sh
+   $ sudo dnf install java-1.8.0-openjdk-devel
+   ```
+2. Install Gradle:
+
+   ```sh
+   $ sudo dnf install gradle
+   ```
 
 
-### Install Java Development Kit 1.8
+You now are ready to get started with the Kotlin track of Exercism!
+
+To get started, see "[Running the Tests](http://exercism.io/languages/kotlin/tests)".
+
+----
+
+# Install Manually
+
+* [Installing on Windows manually](#installing-on-windows-manually)
+* [Installing on Mac OS X without Homebrew](#installing-on-mac-os-x-without-homebrew)
+* [Installing on Linux without a package manager](#installing-on-linux-without-a-package-manager)
+
+----
+
+## Installing on Windows manually
+
+*NOTE: these instructions are intended for experienced Windows users.  If you don't already know how to set environment variables or feel comfortable managing the directory structure, we highly recommend you use the Chocolatey-based install, [above](#windows).*
+
+1. Install the JDK:
+   1. Download "**Java Platform (JDK)**" from [Oracle OTN](http://www.oracle.com/technetwork/java/javase/downloads/index.html).
+   -  Run the installer, using all the defaults.
+2. Install Gradle:
+   - Download "**Binary only distribution**" from the [Gradle download page](https://gradle.org/gradle-download/).
+   - Unzip the archive.  We recommend a place like `C:\Users\JohnDoe\Tools`.
+   - Add a new system environment variable named `GRADLE_HOME` and set it to the path you just created (e.g. `C:\Users\JohnDoe\Tools\gradle-x.y`).
+   - Update the system `Path` to include the `bin` directory from Gradle's home (e.g. `Path`=`...;%GRADLE_HOME%\bin`).
 
 
-First determine if you have Java installed already.
+You now are ready to get started with the Kotlin track of Exercism!
 
-In a Command Prompt window (Start -> Command Prompt)...
+To get started, see "[Running the Tests](http://exercism.io/languages/kotlin/tests)".
 
-```
-C:\Users\johndoe> java -version
-```
+----
 
-if you see:
+## Installing on Mac OS X without Homebrew
 
-```
-'java' is not recognized as an internal or external command,
-operable program or batch file.
-```
+*NOTE: these instructions are intended for experienced Mac OS X users.  Unless you specifically do not want to use a package manager, we highly recommend using the Homebrew-based installation instructions, [above](#mac-os-x).*
 
-You'll need to install the JDK — it contains both a Java Runtime and development tools.
+1. Install the JDK:
+   1. Download "**Java Platform (JDK)**" from [Oracle OTN](http://www.oracle.com/technetwork/java/javase/downloads/index.html).
+   2. Run the installer, using all the defaults.
+2. Install Gradle:
+   1. Download "**Binary only distribution**" from the [Gradle download page](https://gradle.org/gradle-download/).
+   2. Unpack Gradle:
 
-1. Go to [Oracle OTN](http://www.oracle.com/technetwork/java/javase/downloads/index.html) and download the latest version of the JDK (at the time of writing, [JDK 8u91](http://www.oracle.com/technetwork/java/javase/downloads/jdk8-downloads-2133151.html))
-2. Run the installer, using all the defaults.
+      ```sh
+      $ mkdir ~/tools
+      $ cd ~/tools
+      $ unzip ~/Downloads/gradle-*-bin.zip
+      $ cd gradle*
+      ```
+   3. Configure Gradle and add it to the path:
 
-Verify that the install worked.
+      ```sh
+      $ cat << DONE >> ~/.bashrc
+      export GRADLE_HOME=`pwd`
+      export PATH=\$PATH:\$GRADLE_HOME/bin
+     DONE
+     ```
 
-Close any open Command Prompt windows and in a *new* Command Prompt window...
 
-```
-C:\Users\johndoe> java -version
-```
+You now are ready to get started with the Kotlin track of Exercism!
 
-You should see something like this:
+To get started, see "[Running the Tests](http://exercism.io/languages/kotlin/tests)".
 
-```
-java version "1.8.0_45"
-Java(TM) SE Runtime Environment (build 1.8.0_45-b15)
-Java HotSpot(TM) 64-Bit Server VM (build 25.45-b02, mixed mode)
-```
+----
 
-The exact version number is not important, just that version 1.8 or better is installed. Circa 2004, Sun Microsystem, in their inifinite wisdom, decided that it would be "better" to have dual numbering conventions.  Java 1.8 == Java 8.0.
+## Installing on Linux without a package manager
 
-### Install IntelliJ IDEA Community Edition
+*NOTE: these instructions are intended for experienced Linux users.  Unless you specifically do not want to use a package manager, we highly recommend using the the installation instructions, [above](#linux).*
 
-Download, install and configure IntelliJ with the JDK you have installed:
+1. Install the JDK:
+   1. Download "**Java Platform (JDK)**" from [Oracle OTN](http://www.oracle.com/technetwork/java/javase/downloads/index.html).
+   2. Run the installer, using all the defaults.
+2. Install Gradle:
+   1. Download "**Binary only distribution**" from the [Gradle download page](https://gradle.org/gradle-download/).
+   2. Unpack Gradle:
 
-1. Download [IntelliJ IDEA Community Edition](https://www.jetbrains.com/idea/download/) and run the installer; accept all the defaults.
+      ```sh
+      $ mkdir ~/tools
+      $ cd ~/tools
+      $ unzip ~/Downloads/gradle-*-bin.zip
+      $ cd gradle*
+      ```
+   3. Configure Gradle and add it to the path:
 
-2. Run IntelliJ (Start -> All Programs -> JetBrains -> IntelliJ IDEA Community Edition).
-    * The first time you do, IntelliJ walks you through some initial setup.  We recommend selecting a UI Theme and then just clicking "Skip All and Set Defaults".
+      ```sh
+      $ cat << DONE >> ~/.bashrc
+      export GRADLE_HOME=`pwd`
+      export PATH=\$PATH:\$GRADLE_HOME/bin
+     DONE
+     ```
 
-3. In the "Welcome to IntelliJ IDEA" window, open the "Configure" pull-down and select "Project Defaults", then "Project Structure".
+You now are ready to get started with the Kotlin track of Exercism!
 
-3. In the "Default Project Structure" dialog, find the "Project SDK:" section in the right panel.  Click the "New..." button and select "JDK".
+To get started, see "[Running the Tests](http://exercism.io/languages/kotlin/tests)".
 
-4. In the "Select Home Directory for JDK" file open dialog, navigate to "`C:\Program Files\Java\jdk1.8...`".  Be sure to select the JDK, not the JRE.  Click "OK".
+----
 
-5. Back in the "Default Project Structure" dialog, in the "Project language level:" section, select "8 - Lambdas, type annotations etc.".  Click "OK".
+# Java IDEs
 
-## Mac OS X
+There are many Java IDEs available.  The three most popular are:
 
-If you are new-ish to programming in Java on Mac OS X, these instructions are for you.
-This is a step-by-step opinionated guide to getting from zero to submitting your first exercise.
+* [IntelliJ IDEA](https://www.jetbrains.com/idea/download/) (download the "Community" edition)
+  - from the authors of Kotlin, this IDE provides the best support for the language.
+- [Eclipse](https://www.eclipse.org/downloads/)
+- [NetBeans](https://netbeans.org/downloads/) (download the "Java SE" bundle)
 
-### Step 1 — Install Java Development Kit 1.8
+and there are [others](https://en.wikibooks.org/wiki/Java_Programming/Java_IDEs).
 
-First, determine if the JDK 1.8 is installed:
-
-```bash
-$ java -version
-```
-
-What you do next depends on the output of that command.
-
-#### No JDKs Installed
-
-If you have no JDKs installed at all (e.g. you have a fresh install of Mac OS X 10.10 [Yosemite]),
-the OS presents a dialog:
-
-![To use the "java," command-line tool you need to install a JDK.  Click "More Info..." to visit the Java Developer Kit download website.](http://x.exercism.io/v3/tracks/java/docs/img/mac-osx--install-java-dialog.png)
-
-Clicking on the "More Info..." button takes you to the [Oracle OTN](http://www.oracle.com/technetwork/java/javase/downloads/index.html).
-
-Download the latest version of the JDK (at the time of writing,
-[JDK 8u71](http://www.oracle.com/technetwork/java/javase/downloads/jdk8-downloads-2133151.html))
-and run the installer, using all the defaults.
-
-Skip down to [Verify JDK Install](#verify-jdk-install)
-
-#### Older JDKs Installed
-
-If you see something like...
-
-```bash
-java version "1.6.0_65"
-Java(TM) SE Runtime Environment (build 1.6.0_65-b14-462-11M4609)
-Java HotSpot(TM) 64-Bit Server VM (build 20.65-b04-462, mixed mode)
-```
-
-Or any version that is prior to 1.8, you need to install the 1.8 JDK...
-
-1. Go to [Oracle OTN](http://www.oracle.com/technetwork/java/javase/downloads/index.html)
-and download the latest version of the JDK (at the time of writing,
-[JDK 8u91](http://www.oracle.com/technetwork/java/javase/downloads/jdk8-downloads-2133151.html))
-2. Run the installer, using all the defaults.
-
-#### Verify JDK Install
-
-Let's verify that the installation worked...
-
-```bash
-$ java -version
-```
-
-You should see something like this:
-
-```bash
-java version "1.8.0_45"
-Java(TM) SE Runtime Environment (build 1.8.0_45-b15)
-Java HotSpot(TM) 64-Bit Server VM (build 25.45-b02, mixed mode)
-```
-
-The exact version number is not important, just that version 1.8 or better is installed.
-Circa 2004, Sun Microsystem, in their inifinite wisdom, decided that it would be "better" to
-have dual numbering conventions.  Java 1.8 == Java 8.0.
-
-Congratulations, you've ensured you have the proper version of Java, itself, installed!
-
-### Step 2 — Install IntelliJ IDEA Community Edition
-
-Download, install and configure IntelliJ with the JDK you have installed:
-
-1. Download [IntelliJ IDEA Community Edition](https://www.jetbrains.com/idea/download/) and
-run the installer; accept all the defaults.
-
-2. Run IntelliJ (`/Applications/IntelliJ IDEA CE.app`)
-    * The first time you do, IntelliJ walks you through some initial setup.  We recommend
-      selecting a UI Theme and then just clicking "Skip All and Set Defaults".
-
-3. In the "Welcome to IntelliJ IDEA" window, open the "Configure" pull-down and select
-   "Project Defaults", then "Project Structure".
-
-6. In the "Default Project Structure" dialog, find the "Project SDK:" section in the right panel.
-   Click the "New..." button and select "JDK".
-
-5. In the "Select Home Directory for JDK" file open dialog, navigate to
-   `/Library/Java/JavaVirtualMachines/jdk1.8.0_45.jdk/Contents/Home`. Click "OK".
-
-6. Back in the "Default Project Structure" dialog, in the "Project language level:" section,
-   select "8 - Lambdas, type annotations etc.".  Click "OK".

--- a/docs/TESTS.md
+++ b/docs/TESTS.md
@@ -1,175 +1,110 @@
-## Windows
+# Running the Tests
 
-1) In the Command Prompt window, get the first exercise...
+Choose your operating system:
 
-```
-C:\Users\johndoe> exercism fetch kotlin
+* [Windows](#windows)
+* [Mac OS X](#mac-os-x)
+* [Linux](#linux)
 
-New:
-Kotlin (Etl)      C:\Users\johndoe\exercism\kotlin\etl
+----
 
-unchanged: 0, updated: 0, new: 1
-```
+# Windows
 
-2) In the "Welcome to IntelliJ IDEA" window, click the "Open" option.
+1. Open a Command Prompt.
+2. Get the first exercise:
 
-3) Navigate to the "C:\Users\johndoe\exercism\kotlin\etl" folder.  Make sure you've selected the "etl" folder. Click "OK".
+   ```batchfile
+   C:\Users\JohnDoe>exercism fetch kotlin
+   ﻿
+   Not Submitted:     1 problem
+   Kotlin (Hello World) C:\Users\JohnDoe\exercism\kotlin\hello-world
 
-4) In the "Import Project from Gradle" dialog, check the "auto-import" and "create directories" checkboxes and select "Use customizable gradle wrapper".
+   New:               1 problem
+   Kotlin (Hello World) C:\Users\JohnDoe\exercism\kotlin\hello-world
 
-```
-Gradle project:    [C:\Users\johndoe\exercism\kotlin\etl\build.gradle   ](...)
+   unchanged: 0, updated: 0, new: 1
 
-[X] Use auto-import
-[X] Create directories for empty content roots automatically
+   ```
+3. Change directory into the exercism:
 
-( ) Use default gradle wrapper (not configured for the current project)
-(o) Use customizable gradle wrapper
-( ) Use local gradle distribution
+   ```batchfile
+   C:\Users\JohnDoe>cd C:\Users\JohnDoe\exercism\kotlin\hello-world
+   ```
 
-...
-```
+4. Run the tests:
 
-5) Click "OK".  IntelliJ will automatically create its project artifacts based on the Gradle project file.
+   ```batchfile
+   C:\Users\JohnDoe>gradle test
+   ```
+   *(Don't worry about the tests failing, at first, this is how you begin each exercise.)*
+5. Solve the exercise.  Find and work through the `GETTING_STARTED.md` guide ([view on GitHub](https://github.com/exercism/xkotlin/blob/master/exercises/hello-world/GETTING_STARTED.md)).
 
-* After the project has loaded and you've dismissed the "Tip of the Day" dialog, you may see a notice (in the top-right-hand corner), saying, "Unindex remote maven repositories found." you can safely dismiss this notice.
 
-6) Open the `README.md` file and carefully read the background for the assignment.
+Good luck!  Have fun!
 
-7) Start by running the test suite: In the "Project" view, right-click on the test file (`etl\src\test\kotlin\EtlTest`), select "Run", then pick the "EtlTest" that has a JUnit icon to the left of it (red and green arrows), NOT the Gradle icon (circular green).
+If you get stuck, at any point, don't forget to reach out for [help](http://exercism.io/languages/kotlin/help).
 
-* When you first start an exercise, you should expect compilation errors because the test is setting expectations on a class that you need to write.  By trying to run the tests, you get a nice list of what needs to be fixed in the "Messages Make" view.
+----
 
-... and away you go!!!
+# Mac OS X
 
-## Mac OS X
+1. In the terminal window, get the first exercise:
 
-### Get started with the first exercise
+   ```
+   $ exercism fetch kotlin
 
-In the terminal window, get the first exercise:
+   New:                 1 problem
+   Kotlin (Etl) /Users/johndoe/exercism/kotlin/hello-world
 
-    $ exercism fetch kotlin
+   unchanged: 0, updated: 0, new: 1
 
-    Not Submitted:       1 problem
-    Kotlin (Etl) /Users/johndoe/exercism/kotlin/etl
+  ```
+2. Change directory into the exercise:
 
-    New:                 1 problem
-    Kotlin (Etl) /Users/johndoe/exercism/kotlin/etl
+   ```
+   $ cd /Users/johndoe/exercism/kotlin/hello-world
+   ```
+3. Run the tests:
 
-    unchanged: 0, updated: 0, new: 1
+  ```
+  $ gradle test
+  ```
+   *(Don't worry about the tests failing, at first, this is how you begin each exercise.)*
+4. Solve the exercise.  Find and work through the `GETTING_STARTED.md` guide ([view on GitHub](https://github.com/exercism/xkotlin/blob/master/exercises/hello-world/GETTING_STARTED.md)).
 
-### Running the Tests
+Good luck!  Have fun!
 
-#### Option 1: IntelliJ
+If you get stuck, at any point, don't forget to reach out for [help](http://exercism.io/languages/kotlin/help).
 
-1. In the "Welcome to IntelliJ IDEA" window, click the "Open" option.
+----
 
-2. Navigate to the `/Users/johndoe/exercism/kotlin/etl` folder.  Make sure you've selected the
-   "etl" folder. Click "OK".
+# Linux
 
-3. In the "Import Project from Gradle" dialog, check the "auto-import" and "create directories"
-   checkboxes and select "Use customizable gradle wrapper".
+1. In the terminal window, get the first exercise:
 
-    ![IntelliJ 14 CE -- Gradle import dialog](http://x.exercism.io/v3/tracks/kotlin/docs/img/mac-osx--idea-ce-gradle-import-dialog.png)
+   ```
+   $ exercism fetch kotlin
 
-4. Click "OK".  IntelliJ will automatically create its project artifacts based on the Gradle project file.
+   New:                 1 problem
+   Kotlin (Etl) /home/johndoe/exercism/kotlin/hello-world
 
- * After the project has loaded and you've dismissed the "Tip of the Day" dialog, you may see a
-   notice (in the top-right-hand corner), saying, "Unindex remote maven repositories found." you can
-   safely dismiss this notice.
+   unchanged: 0, updated: 0, new: 1
 
-5. Open the `README.md` file and carefully read the background for the assignment.
+  ```
+2. Change directory into the exercise:
 
-6. Start by running the test suite: In the "Project" view, right-click on the test file
-   (`etl\src\test\kotlin\EtlTest`), select "Run", then pick the "EtlTest" that has a JUnit icon to the
-   left of it (red and green arrows), NOT the Gradle icon (circular green).
-   ![Run tests through IDEA JUnit Runner, NOT Gradle](http://x.exercism.io/v3/tracks/kotlin/docs/img/mac-osx--idea-ce-run-unit-tests.png)
+   ```
+   $ cd /home/johndoe/exercism/kotlin/hello-world
+   ```
+3. Run the tests:
 
- * If these menu options don't appear at first, wait for a few seconds and try again; IntelliJ is still
-   configuring the project with a Kotlin nature.
+  ```
+  $ gradle test
+  ```
+   *(Don't worry about the tests failing, at first, this is how you begin each exercise.)*
+4. Solve the exercise.  Find and work through the `GETTING_STARTED.md` guide ([view on GitHub](https://github.com/exercism/xkotlin/blob/master/exercises/hello-world/GETTING_STARTED.md)).
 
- * When you first start an exercise, you should expect compilation errors because the test is
-   setting expectations on a class that you need to write.  By trying to run the tests, you get a
-   nice list of what needs to be fixed in the "Messages Make" view.
+Good luck!  Have fun!
 
-... and away you go!!!
+If you get stuck, at any point, don't forget to reach out for [help](http://exercism.io/languages/kotlin/help).
 
-#### Option 2: Command Line
-
-The Exercism exercises for Kotlin can be built and tested from the command line using [Gradle](https://gradle.org).
-
-After [installing Gradle](https://www.jayway.com/2013/05/12/getting-started-with-gradle), you can run the tests for any exercise by running `gradle test`, as long as you're in the same directory as the `build.gradle` file:
-
-```
-$ pwd
-/Users/johndoe/Code/exercism/kotlin/hello-world
-
-$ gradle test
-...
-
-:test
-
-HelloWorldTest > helloSampleName FAILED
-    org.junit.ComparisonFailure at HelloWorldTest.kt:25
-
-HelloWorldTest > helloNullName FAILED
-    org.junit.ComparisonFailure at HelloWorldTest.kt:20
-
-HelloWorldTest > helloBlankName FAILED
-    org.junit.ComparisonFailure at HelloWorldTest.kt:13
-
-HelloWorldTest > helloNoName FAILED
-    org.junit.ComparisonFailure at HelloWorldTest.kt:8
-
-HelloWorldTest > helloAnotherSampleName FAILED
-    org.junit.ComparisonFailure at HelloWorldTest.kt:30
-
-5 tests completed, 5 failed
-:test FAILED
-
-FAILURE: Build failed with an exception.
-
-* What went wrong:
-Execution failed for task ':test'.
-> There were failing tests. See the report at: file:///Users/johndoe/Code/exercism/kotlin/hello-world/build/reports/tests/test/index.html
-
-* Try:
-Run with --stacktrace option to get the stack trace. Run with --info or --debug option to get more log output.
-
-BUILD FAILED
-
-Total time: 1.141 secs
-```
-
-When test cases are failing, you can get more information about the failing tests by including the `test` task's `--info` option:
-
-```
-$ gradle test --info
-...
-
-:test
-
-...
-
-HelloWorldTest > helloSampleName FAILED
-    org.junit.ComparisonFailure: expected:<Hell[o], Alice!> but was:<Hell[ooo], Alice!>
-        at org.junit.Assert.assertEquals(Assert.java:115)
-        at kotlin.test.junit.JUnitAsserter.assertEquals(JUnitSupport.kt:23)
-        at kotlin.test.AssertionsKt__TestAssertionsKt.assertEquals(TestAssertions.kt:29)
-        at kotlin.test.AssertionsKt.assertEquals(Unknown Source)
-        at kotlin.test.AssertionsKt__TestAssertionsKt.assertEquals$default(TestAssertions.kt:28)
-        at kotlin.test.AssertionsKt.assertEquals$default(Unknown Source)
-        at HelloWorldTest.helloSampleName(HelloWorldTest.kt:25)
-
-...
-
-5 tests completed, 5 failed
-
-...
-
-BUILD FAILED
-
-Total time: 1.162 secs
-
-...
-```

--- a/exercises/hello-world/GETTING_STARTED.md
+++ b/exercises/hello-world/GETTING_STARTED.md
@@ -1,0 +1,50 @@
+----
+# Quick Start Guide
+
+This guide picks-up where [Running the Tests (in Kotlin)](http://exercism.io/languages/kotlin/tests)
+left off.  If you haven't reviewed those instructions, do so now.
+
+Need more information?  A **step-by-step tutorial** is available in this directory at TUTORIAL.md or you can read
+the [HTML version](https://github.com/exercism/xkotlin/blob/master/exercises/hello-world/TUTORIAL.md).
+
+The following instructions work equally well on Windows, Mac OS X and Linux.
+
+## Solve "Hello World"
+
+Try writing a solution that passes one test at a time, running Gradle each time:
+
+
+```
+$ gradle test
+```
+
+## Iterate through the tests
+
+After your first test passes, remove the `@Ignore` from the next test, and iterate on your solution,
+testing after each change.
+
+## All the tests pass?  Submit your solution!
+
+With a working solution that we've reviewed, we're ready to submit it to
+exercism.io.
+
+```
+$ exercism submit src/main/kotlin/HelloWorld.kt
+```
+
+## Next Steps
+
+From here, there are a number of paths you can take.
+
+1. Move on to the next exercise
+2. Review (and comment on) others' submissions to this exercise
+3. Submit another iteration
+4. Contribute to Exercism
+
+
+We sincerely hope you learn and enjoy being part of this community.  If at any time you need assistance
+do not hesitate to ask for help:
+
+http://exercism.io/languages/kotlin/help
+
+Cheers!


### PR DESCRIPTION
This complements #31, directing the user to the tutorial.

It also updates the instructions for installing the runtime; we've gotten far fewer setup questions when using package managers and these instructions are well-tested.