### PR TITLE
Disable incremental compilation and unit test parallelization

### DIFF
--- a/bin/unit-tests.sh
+++ b/bin/unit-tests.sh
@@ -10,6 +10,6 @@ bin/configlet .
 pushd exercises
 echo ""
 echo ">>> Running tests..."
-TERM=dumb ../gradlew check compileStarterSourceKotlin --parallel --continue
+TERM=dumb ../gradlew check compileStarterSourceKotlin --continue
 popd
 

--- a/exercises/gradle.properties
+++ b/exercises/gradle.properties
@@ -1,0 +1,1 @@
+kotlin.incremental=false


### PR DESCRIPTION
- Incremental compilation is not advantageous in a CI environment where
  builds start fresh each time;
- Parallelization of the unit tests was causing unexpected CI failures.
  I was unable to reproduce these failures locally. I tried several
  resolutions including running Kotlin compilation in-process, but none
  fully resolved the issue. Since CI stability is the priority and the
  speed increase obtained by parallelizing the unit tests was small, I
  chose to run the unit tests serially.